### PR TITLE
Added hot server reloading as an option

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "webpack --mode=production",
     "client-dev": "webpack --config ./webpack.config.js --mode development -w",
-    "server-start": "nodemon server/index.js"
+    "server-start": "nodemon server/index.js",
+    "hot-server": "webpack serve --open"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,4 +39,12 @@ module.exports = {
     poll: true,
     ignored: /node_modules/
   },
+  devtool: "eval-cheap-module-source-map",
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'client/dist'),
+    },
+    compress: true,
+    port: 3001,
+  }
 };


### PR DESCRIPTION
Added the hot module reload to the webpack config.  This section I added can be deleted and there would be no issues with webpack.  
All you have to do is type in "run hot-server" into the terminal and go to port 3001 and when you save your code, the browser page will reload automatically.  
Heads up, this is not using our express server and is just for ease of developing the front-end.
You can always go back to running regular nodemon and webpack if you want to.